### PR TITLE
Make _paths non-enumerable, so ESLint 1.8.0's AST deep clone doesn't …

### DIFF
--- a/src/toAST.js
+++ b/src/toAST.js
@@ -17,6 +17,9 @@ var astTransformVisitor = {
     if (node.innerComments) {
       node.trailingComments = node.innerComments;
     }
+
+    // make '_paths' non-enumerable (babel-eslint #200)
+    Object.defineProperty(node, "_paths", { value: node._paths, writable: true })
   },
   exit: function (node) { /* parent */
     if (this.isSpreadProperty()) {


### PR DESCRIPTION
…follow it.

Fixes https://github.com/babel/babel-eslint/issues/200.

May be appropriate to "hide" more of Babel's extraneous keys (`_babelType`, etc) this way, but this solves the immediate problem. 😎
