### PR TITLE
use raw value for Template to keep it consistent with esprima

### DIFF
--- a/src/convertTemplateType.js
+++ b/src/convertTemplateType.js
@@ -1,4 +1,4 @@
-module.exports = function (tokens, tt) {
+module.exports = function (tokens, tt, code) {
   var startingToken    = 0;
   var currentToken     = 0;
   var numBraces        = 0; // track use of {}
@@ -21,16 +21,7 @@ module.exports = function (tokens, tt) {
 
   // append the values between start and end
   function createTemplateValue(start, end) {
-    var value = "";
-    while (start <= end) {
-      if (tokens[start].value) {
-        value += tokens[start].value;
-      } else if (tokens[start].type !== tt.template) {
-        value += tokens[start].type.label;
-      }
-      start++;
-    }
-    return value;
+    return code.slice(tokens[start].start, tokens[end].end);
   }
 
   // create Template token

--- a/src/toTokens.js
+++ b/src/toTokens.js
@@ -5,7 +5,7 @@ var toToken = require("./toToken");
 
 module.exports = function (tokens, tt, code) {
   // transform tokens to type "Template"
-  convertTemplateType(tokens, tt);
+  convertTemplateType(tokens, tt, code);
   var transformedTokens = tokens.filter(function (token) {
     return token.type !== "CommentLine" && token.type !== "CommentBlock";
   });


### PR DESCRIPTION
babel is using the `value.cooked` instead of `value.raw` for the tokens, which is inconsistent with esprima and makes it impossible to rebuild the program based solely on the token list. - see https://phabricator.babeljs.io/T7155 and https://phabricator.babeljs.io/T6833 for more context

I spent the last hour trying to fix it directly on Babel, but this was 10x easier... - I'm not really familiar with Babel codebase.

this should fix https://github.com/millermedeiros/esformatter/issues/414
